### PR TITLE
ci: Create CI job for bumping tool count

### DIFF
--- a/.github/workflows/bump_tool_count.yml
+++ b/.github/workflows/bump_tool_count.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Bump count of tools listed
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run script
+        run: ./bin/update_list_count.sh
+
+      # Runs a set of commands using the runners shell
+      - name: Commit
+        uses: EndBug/add-and-commit@v9.1.2
+        with:
+          message: "chore: Update tool count"
+          actor: github-actions
+          add: 'README.md'
+


### PR DESCRIPTION
This PR adds a CI job that automatically bumps and commits the number of tools listed.

If nothing changes then nothing ends up being committed.

Closes #4