### PR TITLE
docs: add tmux vi navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Terminology:
        set-option -g status-keys vi		# Use Vi bindings in tmux command prompt.
        set-window-option -g mode-keys vi	# Use Vi bindings in copy and choice mode.
 
-       # some Vi like navigation for smart pane switching
+       # Optional: some Vi-like navigation for smart pane switching.
+       # NOTE this could override default keybindigns like <prefix>-l.
        bind h select-pane -L
        bind j select-pane -D
        bind k select-pane -U

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Terminology:
       ```ini
        set-option -g status-keys vi		# Use Vi bindings in tmux command prompt.
        set-window-option -g mode-keys vi	# Use Vi bindings in copy and choice mode.
+
+       # some Vi like navigation for smart pane switching
+       bind h select-pane -L
+       bind j select-pane -D
+       bind k select-pane -U
+       bind l select-pane -R
        ```
     </details>
 * [irssi](https://github.com/shabble/irssi-scripts/tree/master/vim-mode) - the popular IRC client.


### PR DESCRIPTION
Add the following
```ini
# some Vi like navigation for smart pane switching
bind h select-pane -L
bind j select-pane -D
bind k select-pane -U
bind l select-pane -R
```
to the `tmux` entry in list. I'm lost in tmux without these bindings. 

This list is super useful - thanks!  Hopefully someone else will find this small addition helpful. 