### PR TITLE
adding Scrolla hehe

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Terminology:
 * :white_check_mark: [vim-anywhere](https://github.com/cknadler/vim-anywhere) - Spawn a vim buffer from any text input in the operating system.
 * :white_check_mark: [Homerow](https://www.homerow.app/) - Add vim-like navigation to any macOS app.
 * :white_check_mark: [kindaVim](https://kindavim.app/) - Get Vim motions all over macOS, in text fields, text areas, and other UI elements. 
+* :white_check_mark: [Scrolla](https://scrolla.app/) - Scroll in macOS using Vim motions.
 * :white_check_mark: [sketchyvim](https://github.com/FelixKratz/SketchyVim) - Get vim-like navigation in any macOS text field.
 * :white_check_mark: [athame](https://github.com/ardagnir/athame) - Patches your shell to add full Vim support by routing your keystrokes through an actual Vim process.
 * :white_check_mark: ~[kommand](https://www.autohotkey.com/board/topic/42706-kommand-a-cross-application-vim-like-hot-key-solution/)~ - A cross-application Vim-like hot key solution.


### PR DESCRIPTION
i've added Scrolla as it's using Vim motions to scroll. i'll be skipping Wooshy because even tho it's inspired by kV and Vim, it only uses Vim motions if you combine it with kV. by default you just type what you're looking for in the UI, and move targets with macOS normal keyboard shortcuts. i think it's a good complement to kV and Scrolla (that's why i built it), but ultimately it doesn't belong to your awesome Vim repo. 