### PR TITLE
Added entry for AltTab

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Terminology:
 * :white_check_mark: [win-vind](https://github.com/pit-ray/win-vind) - Control the Windows GUI in the same way as Vim.
 * :white_check_mark: [warpd](https://github.com/rvaiya/warpd) - A modal keyboard driven interface for mouse manipulation, Linux (X11/Wayland)
 * :white_check_mark: [keystrokes](https://github.com/Darukutsu/keystrokes) - Record you keystrokes and replay them just like in vim macro, Linux (X11/Wayland)
+* :white_check_mark: [AltTab](https://alt-tab-macos.netlify.app/) - A utility that brings Windows-style Alt-Tab functionality to macOS with Vim key support.  To enable Vim keys, go to:  `Preferences` → `Controls` → `Additional controls` → **Select windows using Vim keys**.
 
 ## System Tools
 * :white_check_mark: [htop-vim](https://aur.archlinux.org/packages/htop-vim/) - A patched version the [htop](https://htop.dev/) interactive process viewer that has vim keybindings for navigation.


### PR DESCRIPTION
### Summary  
This pull request adds **AltTab**, a macOS utility that brings **Windows-style Alt-Tab functionality** to macOS.  

### Features  
Unlike traditional Alt-Tab, which relies on arrow keys for navigation, AltTab has **built-in support for Vim keys** (`h`, `j`, `k`, `l`) for window selection, making it more efficient for Vim users. 