### PR TITLE
Move ble.sh under Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Terminology:
   * ```bash
     set -o vi
     ```
-  * :heavy_plus_sign: [ble.sh](https://github.com/akinomyoga/ble.sh) - Bash Line Editor—a line editor written in pure Bash with syntax highlighting, auto suggestions, vim modes, etc. for Bash interactive sessions.
+  * :heavy_plus_sign: [ble.sh](https://github.com/akinomyoga/ble.sh) (Bash Line Editor) - An interactive plugin `ble.sh` provides a better Vim mode as well as syntax highlighting and autosuggestions.  In addition to the above setting of `set -o vi` in `~/.bashrc` or `set editing-mode vi` in `~/.inputrc`, you can add the following settings in `~/.bashrc` to enable `ble.sh`.
     * ```
       # bashrc
 

--- a/README.md
+++ b/README.md
@@ -303,22 +303,22 @@ Terminology:
     set editing-mode vi
     set keymap vi-insert
     ```
-* :white_check_mark: [ble.sh](https://github.com/akinomyoga/ble.sh) - Bash Line Editor―a line editor written in pure Bash with syntax highlighting, auto suggestions, vim modes, etc. for Bash interactive sessions.
-  * ```
-    # bashrc
-
-    # Add this lines at the top of .bashrc:
-    [[ $- == *i* ]] && source /path/to/blesh/ble.sh --noattach
-
-    # your bashrc settings come here...
-
-    # Add this line at the end of .bashrc:
-    [[ ! ${BLE_VERSION-} ]] || ble-attach
-    ```
 * :white_check_mark: [Bash](https://www.gnu.org/software/bash/) - The preferred method is to set Vi mode in `~/.inputrc` via readline, as you will get Vi mode automatically in all programs using the library. However, if you just want this for bash, put this in your bash startup file e.g. `~/.bashrc`:
   * ```bash
     set -o vi
     ```
+  * :heavy_plus_sign: [ble.sh](https://github.com/akinomyoga/ble.sh) - Bash Line Editor—a line editor written in pure Bash with syntax highlighting, auto suggestions, vim modes, etc. for Bash interactive sessions.
+    * ```
+      # bashrc
+
+      # Add this lines at the top of .bashrc:
+      [[ $- == *i* ]] && source /path/to/blesh/ble.sh --noattach
+
+      # your bashrc settings come here...
+
+      # Add this line at the end of .bashrc:
+      [[ ! ${BLE_VERSION-} ]] || ble-attach
+      ```
 * :white_check_mark: [zsh](https://en.wikipedia.org/wiki/Z_shell) - just put this in your ZSH startup file, most likely `~/.zshrc`:
   * ```bash
     bindkey -v


### PR DESCRIPTION
ble.sh is a plugin of Bash.  Since a plugin for Zsh, `zsh-vi-mode`, is described under the item of Zsh, it makes more sense to put ble.sh under the item of Bash.

Also, the current description sounds like just enabling `ble.sh` makes the vim mode enabled, but it is not true. Ble.sh enhances the vi mode of Bash, so the vi mode of Bash needs to be turned on anyway. The second commit clarifies that `set -o vi` (or `set editing-mode vi`) is needed to enable the vim mode.