### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Terminology:
 * :white_check_mark: [NeoMutt](https://neomutt.org/) - A fork of mutt, intendted to reignite the development.
 * :white_check_mark: [sup](https://sup-heliotrope.github.io/) - a console-based email client for people with a lot of email with Vim-inspired [keyboard shortcuts](https://github.com/sup-heliotrope/sup/wiki/Keyboard-reference).
 * [Thunderbird](https://www.thunderbird.net/en-US/)
-  * :heavy_plus_sign: [Muttator](https://addons.thunderbird.net/en-US/thunderbird/addon/muttator/) - Like Vimperator but for thunderbird.
+  * :heavy_plus_sign: ~[Muttator](https://addons.thunderbird.net/en-US/thunderbird/addon/muttator/)~ - Like Vimperator but for thunderbird.
   * :heavy_plus_sign: ~[teledactyl](https://github.com/5digits/dactyl/tree/master/teledactyl)~
 * :white_check_mark: [aerc](https://aerc-mail.org/) - Terminal email client with Vim keybindings.
 * :white_check_mark: [meli](https://meli.delivery/) - A TUI email client with Vim-like keybindings.


### PR DESCRIPTION
Crossed out Muttator - last commit was 8 years ago, latest version isn't available on the Mozilla addin store, version on there only supports up to 38.0 - 38.*, and one of the developers confirms here (https://github.com/vimperator/vimperator-labs/issues/769#issuecomment-908247117) that Muttator is no longer maintained and doesn't support the latest Thunderbird version